### PR TITLE
Update accuracy claim in README description

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 # FingerprintJS Pro Svelte
 
-[Fingerprint](https://fingerprint.com/) is a device intelligence platform offering 99.5% accurate visitor identification.
+[Fingerprint](https://fingerprint.com/) is a device intelligence platform offering industry-leading accuracy.
 
 FingerprintJS Pro Svelte SDK is an easy way to integrate Fingerprint into your Svelte or [Svelte-kit](https://kit.svelte.dev/) application. See example apps in the [examples](./examples) folder.
 


### PR DESCRIPTION
Replaces `99.5% accurate visitor identification` with `industry-leading accuracy` in the README file.

Related-Task: INTER-1240