### PR TITLE
chore: fix CHANGELOG and enter pre-release mode for 3.0.0-rc

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,13 @@
+{
+  "mode": "pre",
+  "tag": "rc",
+  "initialVersions": {
+    "@fingerprint/svelte": "2.2.1",
+    "svelte5-tests": "0.0.0",
+    "spa": "0.0.0",
+    "svelte-kit-example": "0.0.1",
+    "svelte5-spa": "0.0.0",
+    "svelte5-svelte-kit": "0.0.1"
+  },
+  "changesets": []
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# @fingerprint/svelte
+
 ## [2.2.1](https://github.com/fingerprintjs/fingerprintjs-pro-svelte/compare/v2.2.0...v2.2.1) (2024-07-22)
 
 


### PR DESCRIPTION
## Summary

- Add `# @fingerprint/svelte` title to `CHANGELOG.md` — without it, `changeset version` misparses the file and merges stale v2.2.1 entries into the v3.0.0 release notes.
- Enter changeset pre-release mode (`rc`) so the release workflow publishes `3.0.0-rc.0` first for validation before the final 3.0.0.

## Test plan

- [x] Verify the release notes preview comment no longer shows stale v2.2.1 entries under v3.0.0
- [x] Run `pnpm changeset version` locally and confirm v3.0.0 block only contains the 3 changeset entries
- [ ] After merge: verify release workflow creates a PR that versions to `3.0.0-rc.0`
- [ ] Smoke test: `npm install @fingerprint/svelte@rc` in a Svelte 4 and Svelte 5 app